### PR TITLE
Display errors, rename folder and camelcase

### DIFF
--- a/PagesToFolders.sketchplugin/Contents/Sketch/export.js
+++ b/PagesToFolders.sketchplugin/Contents/Sketch/export.js
@@ -1,42 +1,50 @@
 @import './utilities.js';
 
 function exportAllPages(context) {
+
 	var sketch = context.api();
 	var application = sketch.Application();
 	var doc = context.document;
 	var pages = doc.pages();
 	var fileFolder = doc.fileURL().path().split(doc.displayName())[0];
-
-	var rootFolder = fileFolder + "Pages to Folders/";
-
-	Utilities.deleteAndCreateFolder(rootFolder);
-
-	var pageCounter = 1;
-
-	for (var i = 0; i < pages.count(); i++) {
-		var currentPage = pages[i];
-
-		if (pages[i].name() != "Symbols") {
-			var pageFolderPath = rootFolder + pageCounter.toString() + " \u2013 " + pages[i].name() + "/";
-			Utilities.createFolder(pageFolderPath);
-
-			doc.setCurrentPage(currentPage);
-
-			var artboards = doc.currentPage().artboards();
-
-			for (var j = 0; j < artboards.count(); j++) {
-				var artboard = artboards[j];
-				var artboardNameWithDashesInsteadOfSlashes = Utilities.cleanArtboardName(String(artboard.name()));
-
-				// TODO Try and get the exportable options for each artboard,
-				// and export it that way. If there are no export options,
-				// export the file as a @1x .png file.
-				doc.saveArtboardOrSlice_toFile_(artboard, pageFolderPath + artboardNameWithDashesInsteadOfSlashes + ".png");
+	
+	var rootFolder = fileFolder + "designs/";
+	
+	try {
+		Utilities.deleteAndCreateFolder(rootFolder);
+		
+		var pageCounter = 1;
+		
+		for (var i = 0; i < pages.count(); i++) {
+			var currentPage = pages[i];
+			
+			if (currentPage.name() != "Symbols" && !currentPage.name().startsWith("-") ) {
+				var pageFolderPath = rootFolder + pageCounter.toString() + "\u2013" + Utilities.camelize(pages[i].name()) + "/";
+				Utilities.createFolder(pageFolderPath);
+				
+				doc.setCurrentPage(currentPage);
+				
+				var artboards = doc.currentPage().artboards();
+				
+				for (var j = 0; j < artboards.count(); j++) {
+					var artboard = artboards[j];
+					var artboardNameWithDashesInsteadOfSlashes = Utilities.camelize(Utilities.cleanArtboardName(String(artboard.name())));
+					
+					// TODO Try and get the exportable options for each artboard,
+					// and export it that way. If there are no export options,
+					// export the file as a @1x .png file.
+					doc.saveArtboardOrSlice_toFile_(artboard, pageFolderPath + artboardNameWithDashesInsteadOfSlashes + ".png");
+				}
+				
+				pageCounter = pageCounter + 1;
 			}
-
-			pageCounter = pageCounter + 1;
 		}
+		application.alert("You can find the exported files in a folder next to your original file.", "Export Successful!");
 	}
-
-	application.alert("You can find the exported files in a folder next to your original file.", "Export Successful!");
+	catch(error) {
+		application.alert("An error occurred.", error.toString())
+		// expected output: SyntaxError: unterminated string literal
+		// Note - error messages will vary depending on browser
+	}
 };
+	

--- a/PagesToFolders.sketchplugin/Contents/Sketch/utilities.js
+++ b/PagesToFolders.sketchplugin/Contents/Sketch/utilities.js
@@ -31,3 +31,9 @@ Utilities.cleanArtboardName = function (name) {
 
 	return cleanedUpName;
 };
+
+Utilities.camelize = function (str) {
+	return str.split(" ").map(function(word) {
+		return word.charAt(0).toUpperCase() + word.substring(1, word.length);
+	}).join("");
+}


### PR DESCRIPTION
1. Changed folder name to `designs`
1. Catching errors now in case they occur and displaying to user
1. Added camelcase to artboards and pages

I'm on a project that doesn't work well with paths having spaces so made these changes. Feel free to accept or reject - no hard feelings. I just made the changes for myself and thought others might benefit.

Ideally the case and folder name should be user settings but this is my first time modifying a sketch extension and haven't had time to look into it yet so I just made the changes that'd work for me.